### PR TITLE
add .NET Standard support to rules projects

### DIFF
--- a/rules/Rules.EancomD01BEAN3/Rules.EancomD01BEAN3.csproj
+++ b/rules/Rules.EancomD01BEAN3/Rules.EancomD01BEAN3.csproj
@@ -15,7 +15,7 @@
     <RepositoryUrl>https://github.com/GoVolsGo/EdiWeave/</RepositoryUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/GoVolsGo/EdiWeave/master/Assets/nuget-logo.png</PackageIconUrl>
     <PackageTags>.NET-EDI-Framework EDIFACT X12 HIPAA EANCOM</PackageTags>
-    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.6;netstandard2.0;</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\EdiWeave.Core\EdiWeave.Core.csproj" />

--- a/rules/Rules.EdifactD00A.Eval/Rules.EdifactD00A.Eval.csproj
+++ b/rules/Rules.EdifactD00A.Eval/Rules.EdifactD00A.Eval.csproj
@@ -15,7 +15,7 @@
     <RepositoryUrl>https://github.com/GoVolsGo/EdiWeave/</RepositoryUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/GoVolsGo/EdiWeave/master/Assets/nuget-logo.png</PackageIconUrl>
     <PackageTags>.NET-EDI-Framework EDIFACT X12 HIPAA EANCOM</PackageTags>
-    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.6;netstandard2.0;</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\EdiWeave.Core\EdiWeave.Core.csproj" />

--- a/rules/Rules.EdifactD00A.NoValidation/Rules.EdifactD00A.NoValidation.csproj
+++ b/rules/Rules.EdifactD00A.NoValidation/Rules.EdifactD00A.NoValidation.csproj
@@ -15,7 +15,7 @@
     <RepositoryUrl>https://github.com/GoVolsGo/EdiWeave/</RepositoryUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/GoVolsGo/EdiWeave/master/Assets/nuget-logo.png</PackageIconUrl>
     <PackageTags>.NET-EDI-Framework EDIFACT X12 HIPAA EANCOM</PackageTags>
-    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.6;netstandard2.0;</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\EdiWeave.Core\EdiWeave.Core.csproj" />

--- a/rules/Rules.EdifactD00A.Rep/Rules.EdifactD00A.Rep.csproj
+++ b/rules/Rules.EdifactD00A.Rep/Rules.EdifactD00A.Rep.csproj
@@ -15,7 +15,7 @@
     <RepositoryUrl>https://github.com/GoVolsGo/EdiWeave/</RepositoryUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/GoVolsGo/EdiWeave/master/Assets/nuget-logo.png</PackageIconUrl>
     <PackageTags>.NET-EDI-Framework EDIFACT X12 HIPAA EANCOM</PackageTags>
-    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.6;netstandard2.0;</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\EdiWeave.Core\EdiWeave.Core.csproj" />

--- a/rules/Rules.EdifactD00A/Rules.EdifactD00A.csproj
+++ b/rules/Rules.EdifactD00A/Rules.EdifactD00A.csproj
@@ -15,7 +15,7 @@
     <RepositoryUrl>https://github.com/GoVolsGo/EdiWeave/</RepositoryUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/GoVolsGo/EdiWeave/master/Assets/nuget-logo.png</PackageIconUrl>
     <PackageTags>.NET-EDI-Framework EDIFACT X12 HIPAA EANCOM</PackageTags>
-    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.6;netstandard2.0;</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\EdiWeave.Core\EdiWeave.Core.csproj" />

--- a/rules/Rules.Hipaa004010/Rules.Hipaa004010.csproj
+++ b/rules/Rules.Hipaa004010/Rules.Hipaa004010.csproj
@@ -15,7 +15,7 @@
     <RepositoryUrl>https://github.com/GoVolsGo/EdiWeave/</RepositoryUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/GoVolsGo/EdiWeave/master/Assets/nuget-logo.png</PackageIconUrl>
     <PackageTags>.NET-EDI-Framework EDIFACT X12 HIPAA EANCOM</PackageTags>
-    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.6;netstandard2.0;</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\EdiWeave.Core\EdiWeave.Core.csproj" />

--- a/rules/Rules.Hipaa005010/Rules.Hipaa005010.csproj
+++ b/rules/Rules.Hipaa005010/Rules.Hipaa005010.csproj
@@ -15,7 +15,7 @@
     <RepositoryUrl>https://github.com/GoVolsGo/EdiWeave/</RepositoryUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/GoVolsGo/EdiWeave/master/Assets/nuget-logo.png</PackageIconUrl>
     <PackageTags>.NET-EDI-Framework EDIFACT X12 HIPAA EANCOM</PackageTags>
-    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.6;netstandard2.0;</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\EdiWeave.Core\EdiWeave.Core.csproj" />

--- a/rules/Rules.Vda/Rules.Vda.csproj
+++ b/rules/Rules.Vda/Rules.Vda.csproj
@@ -15,7 +15,7 @@
     <RepositoryUrl>https://github.com/GoVolsGo/EdiWeave/</RepositoryUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/GoVolsGo/EdiWeave/master/Assets/nuget-logo.png</PackageIconUrl>
     <PackageTags>.NET-EDI-Framework EDIFACT X12 HIPAA EANCOM</PackageTags>
-    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.6;netstandard2.0;</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\EdiWeave.Core\EdiWeave.Core.csproj" />

--- a/rules/Rules.X12002040.Eval/Rules.X12002040.Eval.csproj
+++ b/rules/Rules.X12002040.Eval/Rules.X12002040.Eval.csproj
@@ -15,7 +15,7 @@
     <RepositoryUrl>https://github.com/GoVolsGo/EdiWeave/</RepositoryUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/GoVolsGo/EdiWeave/master/Assets/nuget-logo.png</PackageIconUrl>
     <PackageTags>.NET-EDI-Framework EDIFACT X12 HIPAA EANCOM</PackageTags>
-    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.6;netstandard2.0;</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\EdiWeave.Core\EdiWeave.Core.csproj" />

--- a/rules/Rules.X12002040.NoValidation/Rules.X12002040.NoValidation.csproj
+++ b/rules/Rules.X12002040.NoValidation/Rules.X12002040.NoValidation.csproj
@@ -15,7 +15,7 @@
     <RepositoryUrl>https://github.com/GoVolsGo/EdiWeave/</RepositoryUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/GoVolsGo/EdiWeave/master/Assets/nuget-logo.png</PackageIconUrl>
     <PackageTags>.NET-EDI-Framework EDIFACT X12 HIPAA EANCOM</PackageTags>
-    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.6;netstandard2.0;</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\EdiWeave.Core\EdiWeave.Core.csproj" />

--- a/rules/Rules.X12002040.Rep/Rules.X12002040.Rep.csproj
+++ b/rules/Rules.X12002040.Rep/Rules.X12002040.Rep.csproj
@@ -15,7 +15,7 @@
     <RepositoryUrl>https://github.com/GoVolsGo/EdiWeave/</RepositoryUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/GoVolsGo/EdiWeave/master/Assets/nuget-logo.png</PackageIconUrl>
     <PackageTags>.NET-EDI-Framework EDIFACT X12 HIPAA EANCOM</PackageTags>
-    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.6;netstandard2.0;</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\EdiWeave.Core\EdiWeave.Core.csproj" />

--- a/rules/Rules.X12002040/Rules.X12002040.csproj
+++ b/rules/Rules.X12002040/Rules.X12002040.csproj
@@ -15,7 +15,7 @@
     <RepositoryUrl>https://github.com/GoVolsGo/EdiWeave/</RepositoryUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/GoVolsGo/EdiWeave/master/Assets/nuget-logo.png</PackageIconUrl>
     <PackageTags>.NET-EDI-Framework EDIFACT X12 HIPAA EANCOM</PackageTags>
-    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.6;netstandard2.0;</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\EdiWeave.Core\EdiWeave.Core.csproj" />


### PR DESCRIPTION
adding .NET Standard 1.6 and 2.0 support to all the Rules projects to match the Core and Framework projects.